### PR TITLE
Checking for NULL account balance from Drupal state

### DIFF
--- a/complete-application/web/modules/custom/changebank/src/Controller/ChangebankController.php
+++ b/complete-application/web/modules/custom/changebank/src/Controller/ChangebankController.php
@@ -24,8 +24,8 @@ class ChangebankController extends ControllerBase {
    */
   public function accountBalance() {
     $value = \Drupal::state()->get('changebank_form_value');
-    $arguments = $value->getArguments();
-    $dollars = $arguments['@dollars'];
+    $arguments = ($value) ? $value->getArguments() : [];
+    $dollars = $arguments['@dollars'] ?? 0;
     return [
       '#markup' => '<span class="account-balance">$' . $dollars . '</span>',
       '#cache' => [


### PR DESCRIPTION
The first time we enter this page (just after logging in), `\Drupal::state()->get('changebank_form_value')` returns `NULL`, which raises an error when accessing `$value->getArguments()`